### PR TITLE
fix quantization error

### DIFF
--- a/particle.py
+++ b/particle.py
@@ -9,8 +9,8 @@ from kmeans import KMeans, calc_sse
 def quantization_error(centroids: np.ndarray, labels: np.ndarray, data: np.ndarray) -> float:
     error = 0.0
     for i, c in enumerate(centroids):
-        idx = np.where(labels == i)
-        dist = np.linalg.norm(data[idx] - c)
+        idx = np.where(labels == i)[0]
+        dist = np.sum(np.linalg.norm(data[idx] - c, axis=1))
         dist /= len(idx)
         error += dist
     error /= len(centroids)

--- a/particle.py
+++ b/particle.py
@@ -10,7 +10,7 @@ def quantization_error(centroids: np.ndarray, labels: np.ndarray, data: np.ndarr
     error = 0.0
     for i, c in enumerate(centroids):
         idx = np.where(labels == i)[0]
-        dist = np.sum(np.linalg.norm(data[idx] - c, axis=1))
+        dist = np.linalg.norm(data[idx] - c, axis=1).sum()
         dist /= len(idx)
         error += dist
     error /= len(centroids)


### PR DESCRIPTION
Based on the formula in the paper the distances of the points related to cluster j should be summed together.
So for each centroid c ,if there are t closest data points to the centroid, we should have t distances and then we sum them together. I think you have missed the `axis = 1` on the norm function and the `sum` after that. 
Also `np.where()` returns a tuple and therefore `len(idx)` always returns 1. So that was the fix I did on the `idx = np.where(labels == i)` line.